### PR TITLE
v.1.25: Update monitoring part for active runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build_spooler:
-	javac -cp ./libs/alien-cs_v1.4.6.jar -d ./out_spooler ./src/spooler/*.java
+	javac -cp ./libs/alien-cs_v1.4.7.jar -d ./out_spooler ./src/spooler/*.java
 	cp -r config ./out_spooler
 
 build_metadata_tool:

--- a/src/spooler/Main.java
+++ b/src/spooler/Main.java
@@ -286,10 +286,11 @@ public class Main {
 			}
 			logger.log(Level.INFO, "List of active runs: " + result);
 			ApMon apmon = MonitorFactory.getApMonSender();
+			String node = ConfigUtils.getLocalHostname();
 			if (!isSize)
-				apmon.sendParameters("epn2eos", "active_runs_cnt", paramNames.size(), paramNames, paramValues);
+				apmon.sendParameters("epn2eos", node + "_cnt", paramNames.size(), paramNames, paramValues);
 			else
-				apmon.sendParameters("epn2eos", "active_runs_size", paramNames.size(), paramNames, paramValues);
+				apmon.sendParameters("epn2eos", node + "_size", paramNames.size(), paramNames, paramValues);
 		}
 	}
 	private static long totalFilesSize(final ScheduledThreadPoolExecutor s) {

--- a/src/spooler/Spooler.java
+++ b/src/spooler/Spooler.java
@@ -24,6 +24,7 @@ import lazyj.Format;
 class Spooler extends FileOperator {
 	private static final Logger logger = ConfigUtils.getLogger(Spooler.class.getCanonicalName());
 	private static final Monitor monitor = MonitorFactory.getMonitor(Spooler.class.getCanonicalName());
+	private static final Monitor transientDataMonitor = MonitorFactory.getMonitor("epn2eos-transient-data");
 
 	Spooler(FileElement element) {
 		super(element);
@@ -70,24 +71,32 @@ class Spooler extends FileOperator {
 
         if (element.getType().equalsIgnoreCase("raw")) {
         	monitor.addMeasurement("data_RAW_total", element.getSize());
-
         	if (element.getSurl().contains(".root"))
         		monitor.addMeasurement("data_RAW_root", element.getSize());
         	else if (element.getSurl().contains(".tf"))
         		monitor.addMeasurement("data_RAW_tf", element.getSize());
 		} else if (element.getType().equalsIgnoreCase("calib")) {
         	monitor.addMeasurement("data_CALIB_total", element.getSize());
-
 			if (element.getSurl().contains(".root"))
 				monitor.addMeasurement("data_CALIB_root", element.getSize());
 			else if (element.getSurl().contains(".tf"))
 				monitor.addMeasurement("data_CALIB_tf", element.getSize());
+		} else if (element.getType().equalsIgnoreCase("other")) {
+			monitor.addMeasurement("data_OTHER_total", element.getSize());
+			if (element.getSurl().contains(".root"))
+				monitor.addMeasurement("data_OTHER_root", element.getSize());
+			else if (element.getSurl().contains(".tf"))
+				monitor.addMeasurement("data_OTHER_tf", element.getSize());
 		}
 
-        if (element.getSurl().contains(".root"))
-        	monitor.addMeasurement("data_total_root", element.getSize());
-        else if (element.getSurl().contains(".tf"))
-        	monitor.addMeasurement("data_total_tf", element.getSize());
+        if (element.getSurl().contains(".root")) {
+			monitor.addMeasurement("data_total_root", element.getSize());
+			transientDataMonitor.addTransientMeasurement(element.getRun() + "-root", element.getSize());
+		}
+        else if (element.getSurl().contains(".tf")) {
+			monitor.addMeasurement("data_total_tf", element.getSize());
+			transientDataMonitor.addTransientMeasurement(element.getRun() + "-tf", element.getSize());
+		}
 
 		Main.nrDataFilesSent.getAndIncrement();
 		logger.log(Level.INFO, "Total number of data files successfully transferred: "


### PR DESCRIPTION
v.1.25: Update monitoring part for active runs

- send total number of files and total size for each active run to ApMon every minute
- add new metrics:
  - data_OTHER_total
  - data_OTHER_root
  - data_OTHER_tf
  - run-root
  - run-tf
  The last two metrics are for transient monitoring req by David Rohr.
  He wants to see the transfer rate for each run grouped by the file
  type (root/tf).

Signed-off-by: Alice Suiu <alicesuiu17@gmail.com>